### PR TITLE
Split gui client from base class.

### DIFF
--- a/madlib.py
+++ b/madlib.py
@@ -1,6 +1,4 @@
 import random
-from tkinter import Button, Frame, Label, Tk
-import tkinter
 
 
 class Madlib:
@@ -27,32 +25,3 @@ class Madlib:
             random.choice(adjectives)
         )
         return output
-
-
-class App:
-
-    def __init__(self, master):
-
-        frame = Frame(master)
-        frame.pack()
-
-        self.new_madlib_button = Button(
-            frame, text="New Madlib", command=self.new_madlib
-            )
-        self.new_madlib_button.pack(side=tkinter.LEFT)
-        self.quit_button = Button(
-            frame, text="QUIT", fg="red", command=frame.quit
-            )
-        self.quit_button.pack(side=tkinter.RIGHT)
-        self.label = Label(root, text=Madlib().get_madlib())
-        self.label.pack()
-
-    def new_madlib(self):
-        self.label.config(text=Madlib().get_madlib())
-
-root = Tk()
-
-app = App(root)
-
-root.mainloop()
-root.destroy()

--- a/madlib_gui_client.py
+++ b/madlib_gui_client.py
@@ -1,0 +1,32 @@
+from madlib import Madlib
+from tkinter import Button, Frame, Label, Tk
+import tkinter
+
+
+class App:
+
+    def __init__(self, master):
+
+        frame = Frame(master)
+        frame.pack()
+
+        self.new_madlib_button = Button(
+            frame, text="New Madlib", command=self.new_madlib
+            )
+        self.new_madlib_button.pack(side=tkinter.LEFT)
+        self.quit_button = Button(
+            frame, text="QUIT", fg="red", command=frame.quit
+            )
+        self.quit_button.pack(side=tkinter.RIGHT)
+        self.label = Label(root, text=Madlib().get_madlib())
+        self.label.pack()
+
+    def new_madlib(self):
+        self.label.config(text=Madlib().get_madlib())
+
+root = Tk()
+
+app = App(root)
+
+root.mainloop()
+root.destroy()


### PR DESCRIPTION
This pull request splits the TKinter app client out into it's own `madlib_gui_client.py` file. This enables a clean reuse of `madlib.py` by way of `from madlib import Madlib` when considering other clients like web.
